### PR TITLE
Remove debug print statements from minimal_share.py API

### DIFF
--- a/app/api/minimal_share.py
+++ b/app/api/minimal_share.py
@@ -19,7 +19,7 @@ def share_budget_route():
     
     elif request.method == "POST":
         try:
-            print("Processing POST request to /api/share")
+            
             data = request.form
             username = data.get("username")
             message = data.get("message", "")
@@ -61,9 +61,7 @@ def share_budget_route():
             }), 201
             
         except Exception as e:
-            import traceback
-            print(f"Error in share_budget POST: {str(e)}")
-            print(traceback.format_exc())
+            
             return jsonify({"status": "error", "message": str(e)}), 500
 
 def list_shares_route():
@@ -155,7 +153,4 @@ def view_shared_goal(share_id):
         }), 200
         
     except Exception as e:
-        import traceback
-        print(f"Error in view_shared_goal: {str(e)}")
-        print(traceback.format_exc())
         return jsonify({"status": "error", "message": str(e)}), 500


### PR DESCRIPTION
Remove debug print statements from minimal_share.py API

- Removed print statement for logging POST requests
- Removed print statements in exception handling
- Removed unused traceback import

This cleanup improves code quality by eliminating development artifacts from the production codebase. Debug print statements can expose sensitive information in logs and add unnecessary noise to the console output. Removing these statements makes the codebase more production-ready while maintaining all functional behavior.

The error handling remains intact with proper HTTP status codes and client-facing error messages.

Issue: #86